### PR TITLE
Fix for batch limit computation; batch progress bar

### DIFF
--- a/deepcode/src/modules/bundler.py
+++ b/deepcode/src/modules/bundler.py
@@ -164,7 +164,7 @@ class DeepCodeBundler:
 
 
         for batch in separate_batches:
-            if multi_bundle_progress_bar != None:
+            if multi_bundle_progress_bar is None:
                 multi_bundle_progress_bar.update(i)
             i = i + 1
             _upload_missing_to_server(batch)


### PR DESCRIPTION
Sorry, submitted the other pull request too early.

Here are progress output improvements (not perfect yet) and a batch break-up fix (check size limit  before, not after adding to current batch).

Let's do a release (0.0.6) soon?